### PR TITLE
Create Email Address

### DIFF
--- a/Email Address
+++ b/Email Address
@@ -1,0 +1,85 @@
+GitHub Docs
+Account and profile/Personal accounts/Manage email preferences/Set commit email address
+Setting your commit email address
+You can set the email address that is used to author commits on GitHub and on your computer.
+
+Platform navigation
+Mac
+Windows
+Linux
+In this article
+About commit email addresses
+Setting your commit email address on GitHub
+Setting your commit email address in Git
+About commit email addresses
+GitHub uses your commit email address to associate commits with your account on GitHub. You can choose the email address that will be associated with the commits you push from the command line as well as web-based Git operations you make.
+
+For web-based Git operations, you can set your commit email address on GitHub. For commits you push from the command line, you can set your commit email address in Git.
+
+Any commits you made prior to changing your commit email address are still associated with your previous email address.
+
+Note
+
+You cannot verify email addresses from disposable email address services (services that allow you to receive email at a temporary address that expires after a certain time). If you'd like to keep your email address private, you can use a GitHub-provided noreply email address. For more information, see Setting your commit email address.
+
+To use your noreply email address for commits you push from the command line, use that email address when you set your commit email address in Git. To use your noreply address for web-based Git operations, set your commit email address on GitHub and choose to Keep my email address private.
+
+You can also choose to block commits you push from the command line that expose your personal email address. For more information, see Blocking command line pushes that expose your personal email address.
+
+To ensure that commits are attributed to you and appear in your contributions graph, use an email address that is connected to your account on GitHub, or the noreply email address provided to you in your email settings. For more information, see Adding an email address to your GitHub account.
+
+
+Note
+
+If you created your account after July 18, 2017, your noreply email address is an ID number and your username in the form of ID+USERNAME@users.noreply.github.com. If you created your account prior to July 18, 2017, and enabled Keep my email address private prior to that date, your noreply email address is USERNAME@users.noreply.github.com. You can get an ID-based noreply email address by selecting (or deselecting and reselecting) Keep my email address private in your email settings.
+
+If you use your noreply email address for GitHub to make commits and then change your username, those commits will not be associated with your account. This does not apply if you're using the ID-based noreply address from GitHub. For more information, see Changing your GitHub username.
+
+Setting your commit email address on GitHub
+If you haven't enabled email address privacy, you can choose which verified email address to author changes with when you edit, delete, or create files or merge a pull request in the user interface. If you enabled email address privacy, then the commit author email address cannot be changed and will be a no-reply by default. For more information about the exact form the no-reply email address can take, see Setting your commit email address.
+
+In the upper-right corner of any page on GitHub, click your profile photo, then click  Settings.
+
+In the "Access" section of the sidebar, click  Emails.
+
+In "Add email address", type your email address and click Add.
+
+Verify your email address.
+
+In the "Primary email address" dropdown menu, select the email address you'd like to associate with your web-based Git operations.
+
+Screenshot of the "Email" settings page. Under "Primary email address," a dropdown menu, labeled with Octocat's email address, is outlined in orange.
+To keep your email address private when performing web-based Git operations, select Keep my email addresses private.
+
+Setting your commit email address in Git
+You can use the git config command to change the email address you associate with your Git commits. The new email address you set will be visible in any future commits you push to GitHub from the command line. Any commits you made prior to changing your commit email address are still associated with your previous email address.
+
+Setting your email address for every repository on your computer
+Open Terminal.
+
+Set an email address in Git. You can use your GitHub-provided noreply email address or any email address.
+
+git config --global user.email "YOUR_EMAIL"
+Confirm that you have set the email address correctly in Git:
+
+$ git config --global user.email
+email@example.com
+Add the email address to your account on GitHub, so that your commits are attributed to you and appear in your contributions graph. For more information, see Adding an email address to your GitHub account.
+
+Setting your email address for a single repository
+GitHub uses the email address set in your local Git configuration to associate commits pushed from the command line with your account on GitHub.
+
+You can change the email address associated with commits you make in a single repository. This will override your global Git configuration settings in this one repository, but will not affect any other repositories.
+
+Open Terminal.
+
+Change the current working directory to the local repository where you want to configure the email address that you associate with your Git commits.
+
+Set an email address in Git. You can use your GitHub-provided noreply email address or any email address.
+
+git config user.email "YOUR_EMAIL"
+Confirm that you have set the email address correctly in Git:
+
+$ git config user.email
+email@example.com
+Add the email address to your account on GitHub, so that your commits are attributed to you and appear in your contributions graph. For more information, see Adding an email address to your GitHub account.


### PR DESCRIPTION
GitHub Docs
Account and profile/Personal accounts/Manage email preferences/Set commit email address Setting your commit email address
You can set the email address that is used to author commits on GitHub and on your computer.

Platform navigation
Mac
Windows
Linux
In this article
About commit email addresses
Setting your commit email address on GitHub
Setting your commit email address in Git
About commit email addresses
GitHub uses your commit email address to associate commits with your account on GitHub. You can choose the email address that will be associated with the commits you push from the command line as well as web-based Git operations you make.

For web-based Git operations, you can set your commit email address on GitHub. For commits you push from the command line, you can set your commit email address in Git.

Any commits you made prior to changing your commit email address are still associated with your previous email address.

Note

You cannot verify email addresses from disposable email address services (services that allow you to receive email at a temporary address that expires after a certain time). If you'd like to keep your email address private, you can use a GitHub-provided noreply email address. For more information, see Setting your commit email address.

To use your noreply email address for commits you push from the command line, use that email address when you set your commit email address in Git. To use your noreply address for web-based Git operations, set your commit email address on GitHub and choose to Keep my email address private.

You can also choose to block commits you push from the command line that expose your personal email address. For more information, see Blocking command line pushes that expose your personal email address.

To ensure that commits are attributed to you and appear in your contributions graph, use an email address that is connected to your account on GitHub, or the noreply email address provided to you in your email settings. For more information, see Adding an email address to your GitHub account.


Note

If you created your account after July 18, 2017, your noreply email address is an ID number and your username in the form of ID+USERNAME@users.noreply.github.com. If you created your account prior to July 18, 2017, and enabled Keep my email address private prior to that date, your noreply email address is USERNAME@users.noreply.github.com. You can get an ID-based noreply email address by selecting (or deselecting and reselecting) Keep my email address private in your email settings.

If you use your noreply email address for GitHub to make commits and then change your username, those commits will not be associated with your account. This does not apply if you're using the ID-based noreply address from GitHub. For more information, see Changing your GitHub username.

Setting your commit email address on GitHub
If you haven't enabled email address privacy, you can choose which verified email address to author changes with when you edit, delete, or create files or merge a pull request in the user interface. If you enabled email address privacy, then the commit author email address cannot be changed and will be a no-reply by default. For more information about the exact form the no-reply email address can take, see Setting your commit email address.

In the upper-right corner of any page on GitHub, click your profile photo, then click  Settings.

In the "Access" section of the sidebar, click  Emails.

In "Add email address", type your email address and click Add.

Verify your email address.

In the "Primary email address" dropdown menu, select the email address you'd like to associate with your web-based Git operations.

Screenshot of the "Email" settings page. Under "Primary email address," a dropdown menu, labeled with Octocat's email address, is outlined in orange. To keep your email address private when performing web-based Git operations, select Keep my email addresses private.

Setting your commit email address in Git
You can use the git config command to change the email address you associate with your Git commits. The new email address you set will be visible in any future commits you push to GitHub from the command line. Any commits you made prior to changing your commit email address are still associated with your previous email address.

Setting your email address for every repository on your computer Open Terminal.

Set an email address in Git. You can use your GitHub-provided noreply email address or any email address.

git config --global user.email "YOUR_EMAIL"
Confirm that you have set the email address correctly in Git:

$ git config --global user.email
email@example.com
Add the email address to your account on GitHub, so that your commits are attributed to you and appear in your contributions graph. For more information, see Adding an email address to your GitHub account.

Setting your email address for a single repository GitHub uses the email address set in your local Git configuration to associate commits pushed from the command line with your account on GitHub.

You can change the email address associated with commits you make in a single repository. This will override your global Git configuration settings in this one repository, but will not affect any other repositories.

Open Terminal.

Change the current working directory to the local repository where you want to configure the email address that you associate with your Git commits.

Set an email address in Git. You can use your GitHub-provided noreply email address or any email address.

git config user.email "YOUR_EMAIL"
Confirm that you have set the email address correctly in Git:

$ git config user.email
email@example.com
Add the email address to your account on GitHub, so that your commits are attributed to you and appear in your contributions graph. For more information, see Adding an email address to your GitHub account.